### PR TITLE
Normalize schema with a products table

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,0 +1,2 @@
+class Product < ApplicationRecord
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,2 +1,3 @@
 class Product < ApplicationRecord
+  has_many :properties, class_name: 'ProductProperty'
 end

--- a/app/models/product_property.rb
+++ b/app/models/product_property.rb
@@ -1,0 +1,3 @@
+class ProductProperty < ApplicationRecord
+  belongs_to :product
+end

--- a/db/migrate/20181003023415_create_products.rb
+++ b/db/migrate/20181003023415_create_products.rb
@@ -1,0 +1,14 @@
+class CreateProducts < ActiveRecord::Migration[5.1]
+  def change
+    create_table :products do |t|
+      t.string :title
+      t.text :description
+      t.text :sdescription
+      t.string :image
+      t.decimal :price, precision: 18, scale: 4
+      t.decimal :offerprice, precision: 18, scale: 4
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181003023717_create_product_properties.rb
+++ b/db/migrate/20181003023717_create_product_properties.rb
@@ -1,0 +1,11 @@
+class CreateProductProperties < ActiveRecord::Migration[5.1]
+  def change
+    create_table :product_properties do |t|
+      t.belongs_to :product, foreign_key: true
+      t.string :title
+      t.string :value
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180902183159) do
+ActiveRecord::Schema.define(version: 20181003023717) do
 
   create_table "benches", force: :cascade do |t|
     t.string "title"
@@ -524,14 +524,12 @@ ActiveRecord::Schema.define(version: 20180902183159) do
   create_table "order_items", force: :cascade do |t|
     t.integer "order_id", null: false
     t.integer "chair_id", null: false
-    t.integer "sofa_id", null: false
     t.integer "quantity", null: false
     t.decimal "price", precision: 15, scale: 2, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["chair_id"], name: "index_order_items_on_chair_id"
     t.index ["order_id"], name: "index_order_items_on_order_id"
-    t.index ["sofa_id"], name: "index_order_items_on_sofa_id"
   end
 
   create_table "orders", force: :cascade do |t|
@@ -543,6 +541,26 @@ ActiveRecord::Schema.define(version: 20180902183159) do
     t.integer "order_id"
     t.string "token"
     t.index ["order_id"], name: "index_orders_on_order_id"
+  end
+
+  create_table "product_properties", force: :cascade do |t|
+    t.integer "product_id"
+    t.string "title"
+    t.string "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_product_properties_on_product_id"
+  end
+
+  create_table "products", force: :cascade do |t|
+    t.string "title"
+    t.text "description"
+    t.text "sdescription"
+    t.string "image"
+    t.decimal "price", precision: 18, scale: 4
+    t.decimal "offerprice", precision: 18, scale: 4
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "queensizebs", force: :cascade do |t|

--- a/lib/tasks/migrate_to_products.rake
+++ b/lib/tasks/migrate_to_products.rake
@@ -1,0 +1,45 @@
+# run via: rails migrate_to_products
+task :migrate_to_products => :environment do
+  MigrateToProducts.new(Bench.all).with_properties(
+    :coupon,
+    :brand,
+    :color,
+    :warrenty,
+    :material,
+    :height,
+    :width,
+    :depth,
+    :dimension
+  )
+end
+
+class MigrateToProducts
+  attr_reader :model
+
+  def initialize(model)
+    @model = model
+  end
+
+  def with_properties(*properties)
+    model.find_in_batches do |records|
+      records.each do |record|
+        # filter properties that have a value
+        props = properties
+          .zip(properties.map { |prop| record.read_attribute(prop) })
+          .select { |title, value| value.present? }
+          .map do |title, value|
+              ProductProperty.new(title: title.to_s.titleize, value: value)
+          end
+
+        product = Product.create!(
+          title: record.title,
+          description: record.description,
+          sdescription: record.sdescription,
+          price: record.price,
+          offerprice: record.offerprice,
+          properties: props
+        )
+      end
+    end
+  end
+end

--- a/test/fixtures/product_properties.yml
+++ b/test/fixtures/product_properties.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  product: one
+  title: MyString
+  value: MyString
+
+two:
+  product: two
+  title: MyString
+  value: MyString

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/product_property_test.rb
+++ b/test/models/product_property_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ProductPropertyTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ProductTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This PR focuses on normalizing the schema by introducing a two models for `Product` and `ProductProperty`. The properties model is just a key value pair for storing additional information about a product that isn't super specific to any product. By centralizing product information into these two models it makes the system grow much easier because you don't need to introduce a new table for every type of product offered for sale. Instead, you can insert a new record into the `products` table along with an arbitrary list of `properties`.

I've also added an entrypoint for migrating your existing models into the this new schema. This task will run with full access to your rails application. This means you can access any code you would have access to normally within controllers/models/etc...

The interesting part of this task is restructuring the attributes of an existing record into an array of properties for a product. This is done by zipping an array of attribute names with their values, removing attributes with blank values and mapping these key/value pairs to `PropertyMapping`. Looking back I probably should have used `.reject { |key, value| value.blank? }` instead of `.select` but oh well..

By completing this migration it will make adding a shopping cart much easier since you will be able to add a foreign key to a single table `order -> line_items[] -> product`. In addition, it will also simplify the administration ui as you will be able to create/edit from a single form.
